### PR TITLE
Fix "mod 6" of values less than -6

### DIFF
--- a/Ktane-Laundry/Assets/Laundry.cs
+++ b/Ktane-Laundry/Assets/Laundry.cs
@@ -110,9 +110,9 @@ public class Laundry : MonoBehaviour
 
         int[] SolutionStates = new int[4];
         int solved = BombInfo.GetSolvedModuleNames().Count;
-        int ItemClothing = (BombInfo.GetSolvableModuleNames().Count - solved + TotalIndicators + 6) % 6;
-        int ItemMaterial = (TotalPorts + solved - BatteryHolders + 6) % 6;
-        int ItemColor = (LastDigitSerial + TotalBatteries + 6) % 6;
+        int ItemClothing = Mod6(BombInfo.GetSolvableModuleNames().Count - solved + TotalIndicators);
+        int ItemMaterial = Mod6(TotalPorts + solved - BatteryHolders);
+        int ItemColor = Mod6(LastDigitSerial + TotalBatteries);
         LogString.AppendFormat("Clothing: {0} ({1}), Material: {2} ({3}), Color: {4} ({5})\n", ClothingNames[ItemClothing], ItemClothing, MaterialNames[ItemMaterial], ItemMaterial, ColorNames[ItemColor], ItemColor);
 
         bool CloudedPearl = ItemColor == 4;
@@ -168,6 +168,11 @@ public class Laundry : MonoBehaviour
         LogString.Append(SpecialText[SolutionStates[3]]);
         LogString.Append("\n");
         return SolutionStates;
+    }
+    
+    int Mod6(int val)
+    {
+        return (val %= 6 < 0) ? val + 6 : val;
     }
 
     void RightKnob()


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5440788/27473177-2e3ee3a2-57cc-11e7-9709-e214631d35a3.png)


IndexOutOfRangeException: Array index is out of range.
  at Laundry.GetSolutionValues (System.Text.StringBuilder& LogString) [0x00000] in <filename unknown>:0 
  at Laundry.UseCoin () [0x00000] in <filename unknown>:0 
  at Laundry.<Start>m__2 () [0x00000] in <filename unknown>:0 
  at ModSelectable.ProxyOnInteract () [0x00000] in <filename unknown>:0 
  at Selectable.HandleInteract () [0x00000] in <filename unknown>:0 
  at SelectableManager.HandleInteract () [0x00000] in <filename unknown>:0 
  at MouseControls.Interact () [0x00000] in <filename unknown>:0 
  at MouseControls.Update () [0x00000] in <filename unknown>:0 
 
(Filename:  Line: -1)